### PR TITLE
v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2025-03-08
+
+### Changed
+
+- Bump version to 0.2.10
+- Increase Diagrammer.Core minimum version requirement to v0.2.20
+- Enforce connections to the Domain Controller using its Fully Qualified Domain Name (FQDN) instead of its IP address
+- Enhance code to handle scenarios where no infrastructure is available for diagramming
+
+### Fixed
+
+- Fix issue where the Server 2025 domain mode was not being detected correctly
+
 ## [0.2.9] - 2025-03-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.10] - 2025-03-08
+## [0.2.10] - 2025-04-08
 
 ### Changed
 

--- a/Diagrammer.Microsoft.AD.psd1
+++ b/Diagrammer.Microsoft.AD.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Diagrammer.Microsoft.AD.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.2.9'
+    ModuleVersion = '0.2.10'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -58,7 +58,7 @@
         },
         @{
             ModuleName = 'Diagrammer.Core';
-            ModuleVersion = '0.2.19';
+            ModuleVersion = '0.2.20';
         }
     )
 

--- a/Language/en-US/New-ADDiagram.psd1
+++ b/Language/en-US/New-ADDiagram.psd1
@@ -57,7 +57,7 @@ ConvertFrom-StringData @'
     siteLinkCost = Site Link Cost
     siteLinkFrequency = Site Link Frequency
     siteLinkFrequencyMinutes = minutes
-    siteLinkName = SiteLink:
+    siteLinkName = Site Link
     NoSiteDC = No Site Domain Controllers
     emptySites = No Site topology available to diagram
     connectingSites = Collecting Microsoft AD Sites information from {0}.

--- a/Language/es-ES/New-ADDiagram.psd1
+++ b/Language/es-ES/New-ADDiagram.psd1
@@ -57,7 +57,7 @@ ConvertFrom-StringData @'
     siteLinkCost = Costo del enlace del sitio
     siteLinkFrequency = Frecuencia del enlace del sitio
     siteLinkFrequencyMinutes = minutos
-    siteLinkName = Enlace del sitio:
+    siteLinkName = Enlace del sitio
     NoSiteDC = No hay controladores de dominio del sitio
     emptySites = No hay topología de sitio disponible para diagramar
     connectingSites = Recopilando información de sitios de Microsoft AD desde {0}.

--- a/Src/Private/Get-ADCaInfo.ps1
+++ b/Src/Private/Get-ADCaInfo.ps1
@@ -3,9 +3,9 @@ function Get-ADCAInfo {
     .SYNOPSIS
         Function to extract microsoft active directory certificate authority information.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.8
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-ADForestInfo.ps1
+++ b/Src/Private/Get-ADForestInfo.ps1
@@ -3,9 +3,9 @@ function Get-ADForestInfo {
     .SYNOPSIS
         Function to extract microsoft active directory forest information.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.8
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -43,7 +43,7 @@ function Get-ADForestInfo {
                         Windows2012R2Forest = 'Windows Server 2012 R2 (Forest)'
                         Windows2016Domain = 'Windows Server 2016 (Domain)'
                         Windows2016Forest = 'Windows Server 2016 (Forest)'
-                        Windows20225Domain = 'Windows Server 2025 (Domain)'
+                        Windows2025Domain = 'Windows Server 2025 (Domain)'
                         Windows2025Forest = 'Windows Server 2025 (Forest)'
                     }
 

--- a/Src/Private/Get-ADSitesInfo.ps1
+++ b/Src/Private/Get-ADSitesInfo.ps1
@@ -3,9 +3,9 @@ function Get-ADSitesInfo {
     .SYNOPSIS
         Function to extract microsoft active directory sites information.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.8
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -37,6 +37,7 @@ function Get-ADSitesInfo {
                                     'Name' = $Link
                                     'Sites' = $SitesLinkInfo.SitesIncluded | ForEach-Object { ConvertTo-ADObjectName -Session $TempPssSession -DN $_ -DC $System }
                                     'AditionalInfo' = [PSCustomObject][ordered]@{
+                                        $translate.siteLinkName  = $Link
                                         $translate.siteLinkCost = $SitesLinkInfo.Cost
                                         $translate.siteLinkFrequency = "$($SitesLinkInfo.ReplicationFrequencyInMinutes) $($translate.siteLinkFrequencyMinutes)"
                                     }

--- a/Src/Private/Get-ADSitesInventoryInfo.ps1
+++ b/Src/Private/Get-ADSitesInventoryInfo.ps1
@@ -3,9 +3,9 @@ function Get-ADSitesInventoryInfo {
     .SYNOPSIS
         Function to extract microsoft active directory sites information.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.8
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-ADTrustInfo.ps1
+++ b/Src/Private/Get-ADTrustInfo.ps1
@@ -3,9 +3,9 @@ function Get-ADTrustsInfo {
     .SYNOPSIS
         Function to extract microsoft active directory trust information.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.8
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -24,13 +24,9 @@ function Get-ADTrustsInfo {
         Write-Verbose -Message ($translate.buildingTrusts -f $($ForestRoot))
         try {
 
-            $TrustDomain = Invoke-Command -Session $TempPssSession { ([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()).GetAllTrustRelationships() }
-            $TrustForest = Invoke-Command -Session $TempPssSession { [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().GetAllTrustRelationships() }
-
-
             $Trusts = @()
-            $Trusts += $TrustDomain
-            $Trusts += $TrustForest
+            $Trusts += Invoke-Command -Session $TempPssSession { ([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()).GetAllTrustRelationships() }
+            $Trusts += Invoke-Command -Session $TempPssSession { [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().GetAllTrustRelationships() }
 
             $TrustsInfo = @()
             if ($Trusts) {

--- a/Src/Private/Get-DiagCertificateAuthority.ps1
+++ b/Src/Private/Get-DiagCertificateAuthority.ps1
@@ -3,9 +3,9 @@ function Get-DiagCertificateAuthority {
     .SYNOPSIS
         Function to diagram Microsoft Active Directory Certificate Authority.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.9
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -61,7 +61,7 @@ function Get-DiagCertificateAuthority {
                         }
                     }
                 } else {
-                    Node -Name NoDomain @{Label = $translate.NoCA; shape = "rectangle"; labelloc = 'c'; fixedsize = $true; width = "3"; height = "2"; fillColor = 'transparent'; penwidth = 1.5; style = 'dashed'; color = 'gray' }
+                    Node -Name NoDomain @{Label = $translate.NoCA; shape = "rectangle"; labelloc = 'c'; fixedsize = $true; width = "5"; height = "3"; fillColor = 'transparent'; penwidth = 1.5; style = 'dashed'; color = 'gray' }
                 }
             }
         } catch {

--- a/Src/Private/Get-DiagForest.ps1
+++ b/Src/Private/Get-DiagForest.ps1
@@ -3,9 +3,9 @@ function Get-DiagForest {
     .SYNOPSIS
         Function to diagram Microsoft Active Directory Forest.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.9
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-DiagSite.ps1
+++ b/Src/Private/Get-DiagSite.ps1
@@ -3,9 +3,9 @@ function Get-DiagSite {
     .SYNOPSIS
         Function to diagram Microsoft Active Directory Forest.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.9
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -40,7 +40,7 @@ function Get-DiagSite {
                                     Node -Name $Site -Attributes @{Label = $SitesObj.Name; penwidth = 1; width = 2; height = .5}
                                     foreach ($Link in $SitesObj.SiteLink) {
                                         $SiteLink = Remove-SpecialChar -String $Link.Name -SpecialChars '\-. '
-                                        Node -Name $SiteLink -Attributes @{Label = (Get-DiaNodeIcon -Name "$($translate.siteLinkName)  $($Link.Name)" -IconType "NoIcon" -Align "Center" -IconDebug $IconDebug -RowsOrdered $Link.AditionalInfo -FontSize 10 -NoFontBold); shape = "plain"; fillColor = 'transparent'}
+                                        Node -Name $SiteLink -Attributes @{Label = (Get-DiaNodeIcon -Name ' ' -IconType "NoIcon" -Align "Center" -IconDebug $IconDebug -RowsOrdered $Link.AditionalInfo -FontSize 10 -NoFontBold); shape = "plain"; fillColor = 'transparent'}
                                         Edge -From $Site -To $SiteLink @{minlen = 2; arrowtail = 'none'; arrowhead = 'none'}
                                         foreach ($SiteLinkSite in $Link.Sites) {
                                             $SiteIncluded = Remove-SpecialChar -String $SiteLinkSite -SpecialChars '\-. '

--- a/Src/Private/Get-DiagSiteInventory.ps1
+++ b/Src/Private/Get-DiagSiteInventory.ps1
@@ -3,9 +3,9 @@ function Get-DiagSiteInventory {
     .SYNOPSIS
         Function to diagram Microsoft Active Directory Sites Inventory.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.9
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-DiagTrust.ps1
+++ b/Src/Private/Get-DiagTrust.ps1
@@ -3,9 +3,9 @@ function Get-DiagTrust {
     .SYNOPSIS
         Function to diagram Microsoft Active Directory Trusts.
     .DESCRIPTION
-        Build a diagram of the configuration of Microsoft Active Directory in PDF/PNG/SVG formats using Psgraph.
+        Build a diagram of the configuration of Microsoft Active Directory to a supported formats using Psgraph.
     .NOTES
-        Version:        0.2.9
+        Version:        0.2.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -51,7 +51,7 @@ function Get-DiagTrust {
                         }
                     }
                 } else {
-                    Node -Name NoTrusts -Attributes @{Label = $translate.NoTrusts; shape = "rectangle"; labelloc = 'c'; fixedsize = $true; width = "3"; height = "2"; fillColor = 'transparent'; penwidth = 0 }
+                    Node -Name NoTrusts @{Label = $translate.NoTrusts; shape = "rectangle"; labelloc = 'c'; fixedsize = $true; width = "3"; height = "2"; fillColor = 'transparent'; penwidth = 1.5; style = 'dashed'; color = 'gray' }
                 }
             }
         } catch {

--- a/Src/Public/New-ADDiagram.ps1
+++ b/Src/Public/New-ADDiagram.ps1
@@ -1,9 +1,9 @@
 function New-ADDiagram {
     <#
     .SYNOPSIS
-        Diagram the configuration of Microsoft AD infrastructure in PDF/SVG/DOT/PNG formats using PSGraph and Graphviz.
+        Diagram the configuration of Microsoft AD infrastructure to a supported formats using PSGraph and Graphviz.
     .DESCRIPTION
-        Diagram the configuration of Microsoft AD  infrastructure in PDF/SVG/DOT/PNG formats using PSGraph and Graphviz.
+        Diagram the configuration of Microsoft AD  infrastructure to a supported formats using PSGraph and Graphviz.
     .PARAMETER DiagramType
         Specifies the type of active directory diagram that will be generated.
         The supported output diagrams are:
@@ -22,7 +22,7 @@ function New-ADDiagram {
         Specifies the password for the target system.
     .PARAMETER Format
         Specifies the output format of the diagram.
-        The supported output formats are PDF, PNG, DOT & SVG.
+        The supported output formats are JPG, PDF, PNG, DOT & SVG.
         Multiple output formats may be specified, separated by a comma.
     .PARAMETER Direction
         Set the direction in which resource are plotted on the visualization
@@ -431,6 +431,10 @@ function New-ADDiagram {
 
     process {
         foreach ($System in $Target) {
+
+            if (Select-String -InputObject $System -Pattern "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$") {
+                throw "Please use the Fully Qualified Domain Name (FQDN) instead of an IP address when connecting to the Domain Controller: $System"
+            }
 
             try {
                 # Connection setup


### PR DESCRIPTION
## [0.2.10] - 2025-04-08

### Changed

- Bump version to 0.2.10
- Increase Diagrammer.Core minimum version requirement to v0.2.20
- Enforce connections to the Domain Controller using its Fully Qualified Domain Name (FQDN) instead of its IP address
- Enhance code to handle scenarios where no infrastructure is available for diagramming

### Fixed

- Fix issue where the Server 2025 domain mode was not being detected correctly